### PR TITLE
Generating a change paper gives no name for the branch in the progress dialog #17

### DIFF
--- a/src/app/branches/branch-publish/branch-publish.component.ts
+++ b/src/app/branches/branch-publish/branch-publish.component.ts
@@ -70,7 +70,7 @@ export class BranchPublishComponent implements OnInit {
     >(ProgressDialogComponent, {
       data: {
         title: this.dialogTitles.get(generationType),
-        message: `Generating the ${this.dialogTitles.get(generationType)} now for the branch "${this.branch?.branchName ?? this.branch?.label ?? ''}". This will take some time, please wait...`
+        message: `Generating the ${this.dialogTitles.get(generationType)} now for the branch "${this.branch?.branchName ?? this.branch?.versionDisplay ?? ''}". This will take some time, please wait...`
       }
     });
     this.isBusy = true;
@@ -108,7 +108,7 @@ export class BranchPublishComponent implements OnInit {
           }
 
           this.toastr.success(
-            `${this.dialogTitles.get(generationType)} generated successfully for branch "${this.branch?.branchName ?? this.branch?.label ?? ''}"`
+            `${this.dialogTitles.get(generationType)} generated successfully for branch "${this.branch?.branchName ?? this.branch?.versionDisplay ?? ''}"`
           );
 
           const blob = new Blob([response.body], {


### PR DESCRIPTION
Not all branches show this problem when generating the change paper—looks like it might only affect finalised branches,

The cause seems to be that the `branchName` property of the `Branch` interface is not set for finalised branches so this has been changed to using the `label` property when `branchName` is undefined.

Unable to find any code that sets `branchName` and maybe unconditionally using the label property value would be better.

Resolves #17 