### PR TITLE
gh-21 Fix delay bug showing OIDC buttons in sign-in dialog

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -22,6 +22,7 @@ import { FooterComponent } from './layout/footer/footer.component';
 import { NavbarComponent } from './layout/navbar/navbar.component';
 import { LoadingIndicatorComponent } from './shared/loading-indicator/loading-indicator.component';
 import { ComponentHarness, setupTestModuleForComponent } from './testing/testing.helpers';
+import { FeaturesService } from './core/features/features.service';
 
 describe('AppComponent', () => {
   let harness: ComponentHarness<AppComponent>;
@@ -32,6 +33,12 @@ describe('AppComponent', () => {
         MockComponent(NavbarComponent),
         MockComponent(FooterComponent),
         MockComponent(LoadingIndicatorComponent)
+      ],
+      providers: [
+        {
+          provide: FeaturesService,
+          useValue: jest.fn()
+        }
       ]
     });
   });
@@ -40,7 +47,7 @@ describe('AppComponent', () => {
     expect(harness?.isComponentCreated).toBeTruthy();
   });
 
-  it('should have as title \'nhsd-datadictionary-orchestration\'', () => {
+  it('should have as title "nhsd-datadictionary-orchestration"', () => {
     expect(harness.component.title).toEqual('nhsd-datadictionary-orchestration');
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -37,6 +37,7 @@ import {
 import { ThemingService } from './core/theming/theming.service';
 import { UserIdleService } from './external/user-idle/user-idle.service';
 import { UserDetails } from './core/security/security.model';
+import { FeaturesService } from './core/features/features.service';
 
 @Component({
   selector: 'mdm-root',
@@ -98,7 +99,8 @@ export class AppComponent implements OnInit, OnDestroy {
     private toastr: ToastrService,
     private theming: ThemingService,
     private overlayContainer: OverlayContainer,
-    private userIdle: UserIdleService
+    private userIdle: UserIdleService,
+    private features: FeaturesService
   ) {}
 
   @HostListener('window:mousemove', ['$event'])
@@ -108,6 +110,12 @@ export class AppComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.setTheme();
+
+    if (this.features.useOpenIdConnect) {
+      // This is a startup test. Loading features may require a server endpoint request to complete, so start it
+      // here before the sign-in-dialog is opened so the user doesn't notice any delay
+      console.log('OpenID Connect allowed');
+    }
 
     this.broadcast
       .on(BroadcastEvent.ApplicationOffline)

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -29,6 +29,6 @@ export const environment = {
   appDescription: 'Orchestrates the data dictionary created by NHS England.',
   checkSessionExpiryTimeout: 300000,
   features: {
-    useOpenIdConnect: false
+    useOpenIdConnect: true
   }
 };


### PR DESCRIPTION
I think the issue was because of configuration and server timing, so checking Mauro API properties was finishing just as the sign-in dialog was checking whether it should display buttons.

Fixed this in two ways:

- Production builds configured to always allow OpenID Connect, assuming there are providers available
- Load the FeaturesService in AppComponent on first load to guarantee feature flags are checked before the user does anything

Fixes #21 