### PR TITLE
gh-26 Fix integrity check links to terms

### DIFF
--- a/src/app/core/url-generator/url-generator.service.ts
+++ b/src/app/core/url-generator/url-generator.service.ts
@@ -68,7 +68,7 @@ export class UrlGeneratorService {
     ],
     [
       DomainType.Term,
-      (modelId, parentId, catalogueId) => `/term/${parentId}/${catalogueId}`
+      (modelId, parentId, catalogueId) => `/term/${modelId}/${catalogueId}`
     ],
     [DomainType.CodeSet, (modelId, parentId, catalogueId) => `/codeSet/${catalogueId}`]
   ]);


### PR DESCRIPTION
# Overview

URL was using the wrong parent ID for the path to the owning terminology

Fixes #26 

# Testing

1. Sign in to the Orchestrator
2. Click on "Branches", then select a branch e.g. `main`
3. Go to the "Integrity" tab and click "Run", then wait for it to complete
4. There should be issues under the category "All items have an alias", select this.
5. Search the item list on the right for items like the "NHS Business Definition" or "Supporting Information" type
6. Make sure these links take you to the named item in Mauro