### PR TITLE
Updates for previewing change papers

### DIFF
--- a/src/app/branches/branch-publish/branch-publish.component.html
+++ b/src/app/branches/branch-publish/branch-publish.component.html
@@ -95,7 +95,7 @@ SPDX-License-Identifier: Apache-2.0
             <button
               mat-flat-button
               color="primary"
-              (click)="generate('')"
+              (click)="generate('websiteDita')"
               [disabled]="isBusy"
             >
               <i class="fas fa-tools"></i>

--- a/src/app/branches/branch-publish/branch-publish.component.ts
+++ b/src/app/branches/branch-publish/branch-publish.component.ts
@@ -39,7 +39,9 @@ export class BranchPublishComponent implements OnInit {
   dialogTitles = new Map<string, string>([
     ['codeSystems', 'FHIR CodeSystems'],
     ['valueSets', 'FHIR ValueSets'],
-    ['changePaper', 'Change Paper']
+    ['changePaper', 'Change Paper'],
+    ['changePaperWithDataSet', 'Change Paper with Data Set Definitions'],
+    ['websiteDita', 'Data Dictionary website']
   ]);
 
   /*  generateFunctions = new Map<string, Function>( [

--- a/src/app/changes/changes-home/changes-home.component.html
+++ b/src/app/changes/changes-home/changes-home.component.html
@@ -76,28 +76,7 @@ SPDX-License-Identifier: Apache-2.0
         <dd>{{ changePaperPreview.publicationDate }}</dd>
 
         <dt>Background</dt>
-        <dd>
-          <p>
-            This Change Request adds the CRXXXX Data Set and supporting definitions to the
-            NHS Data Model and Dictionary to support the Information Standard.
-          </p>
-          <p>
-            A short demonstration is available which describes "How to Read an NHS Data
-            Model and Dictionary Change Request", in an easy to understand screen capture
-            including a voice over and readable captions. This demonstration can be viewed
-            at:
-            <a href="https://datadictionary.nhs.uk/elearning/change_request/index.html"
-              >https://datadictionary.nhs.uk/elearning/change_request/index.html</a
-            >.
-          </p>
-          <p>
-            Note: if the web page does not open, please copy the link and paste into the
-            web browser. A guide to how to use the demonstration can be found at:
-            <a href="https://datadictionary.nhs.uk/help/demonstrations.html"
-              >Demonstrations</a
-            >.
-          </p>
-        </dd>
+        <dd [innerHTML]="changePaperPreview.background"></dd>
 
         <dt>Sponsor</dt>
         <dd>{{ changePaperPreview.sponsor }}</dd>
@@ -116,7 +95,7 @@ SPDX-License-Identifier: Apache-2.0
               <a href="">{{ changedItem.name }}</a>
             </td>
             <td>
-              <p *ngFor="let change of changedItem.changes">{{ change.changeType }}</p>
+              {{ getChangeTypeString(changedItem) }}
             </td>
           </tr>
         </table>

--- a/src/app/changes/changes-home/changes-home.component.html
+++ b/src/app/changes/changes-home/changes-home.component.html
@@ -32,6 +32,11 @@ SPDX-License-Identifier: Apache-2.0
       </p>
     </div>
     <div class="mdm-branch-integrity__toolbar">
+      <mat-checkbox [(ngModel)]="includeDataSets" [disabled]="running"
+        >Include data set defintions</mat-checkbox
+      >
+    </div>
+    <div class="mdm-branch-integrity__toolbar">
       <button
         mat-flat-button
         color="primary"

--- a/src/app/changes/changes-home/changes-home.component.ts
+++ b/src/app/changes/changes-home/changes-home.component.ts
@@ -38,6 +38,7 @@ import { finalize } from 'rxjs/operators';
 export class ChangesHomeComponent implements OnInit {
   branchId = '';
   branch?: Branch;
+  includeDataSets = false;
   running = false;
   changePaperPreview: ChangePaperPreview | undefined;
 
@@ -75,7 +76,7 @@ export class ChangesHomeComponent implements OnInit {
     this.running = true;
 
     this.dataDictionary
-      .getChangePaperPreview(this.branchId)
+      .getChangePaperPreview(this.branchId, this.includeDataSets)
       .pipe(finalize(() => (this.running = false)))
       .subscribe((changePaperPreview) => {
         this.changePaperPreview = changePaperPreview;

--- a/src/app/changes/changes-home/changes-home.component.ts
+++ b/src/app/changes/changes-home/changes-home.component.ts
@@ -24,6 +24,7 @@ import {
 } from '@mdm/core/state-handler/state-handler.service';
 import {
   Branch,
+  ChangedItem,
   ChangePaperPreview
 } from '@mdm/mdm-resources/mdm-resources/adapters/nhs-data-dictionary.model';
 import { DataDictionaryService } from '@mdm/core/data-dictionary/data-dictionary.service';
@@ -60,6 +61,10 @@ export class ChangesHomeComponent implements OnInit {
     this.dataDictionary.getAvailableBranches().subscribe((branches) => {
       this.branch = branches.find((b) => b.id === this.branchId);
     });
+  }
+
+  getChangeTypeString(changedItem: ChangedItem) {
+    return changedItem.changes.map((c) => c.changeType).join(', ');
   }
 
   private load(): void {

--- a/src/app/core/data-dictionary/data-dictionary.service.ts
+++ b/src/app/core/data-dictionary/data-dictionary.service.ts
@@ -63,8 +63,11 @@ export class DataDictionaryService {
     );
   }
 
-  getChangePaperPreview(branch: string): Observable<ChangePaperPreview> {
-    return this.nhsDataDictionary.previewChangePaper(branch).pipe(
+  getChangePaperPreview(
+    branch: string,
+    includeDataSets: boolean
+  ): Observable<ChangePaperPreview> {
+    return this.nhsDataDictionary.previewChangePaper(branch, includeDataSets).pipe(
       catchError((error) => {
         this.logging.error(
           `There was a problem getting change paper preview for the "${branch}" branch.`,

--- a/src/app/mdm-resources/mdm-resources/adapters/nhs-data-dictionary.service.ts
+++ b/src/app/mdm-resources/mdm-resources/adapters/nhs-data-dictionary.service.ts
@@ -57,9 +57,12 @@ export class NhsDataDictionaryService {
       .pipe(map((response: StatisticsResponse) => response.body));
   }
 
-  previewChangePaper(branch: string): Observable<ChangePaperPreview> {
+  previewChangePaper(
+    branch: string,
+    includeDataSets: boolean
+  ): Observable<ChangePaperPreview> {
     return this.resources.dataDictionary
-      .previewChangePaper(branch)
+      .previewChangePaper(branch, includeDataSets)
       .pipe(map((response: ChangePaperPreviewResponse) => response.body));
   }
 

--- a/src/app/mdm-resources/plugins/mdm-plugin-nhs-data-dictionary.resource.ts
+++ b/src/app/mdm-resources/plugins/mdm-plugin-nhs-data-dictionary.resource.ts
@@ -42,10 +42,11 @@ export class MdmPluginNhsDataDictionaryResource extends MdmResource {
 
   previewChangePaper(
     branch: string,
+    includeDataSets: boolean,
     queryStringParams?: QueryParameters,
     restHandlerOptions?: RequestSettings
   ): any {
-    const url = `${this.apiEndpoint}/nhsdd/${branch}/preview/changePaper`;
+    const url = `${this.apiEndpoint}/nhsdd/${branch}/preview/changePaper?includeDataSets=${includeDataSets}`;
     return this.simpleGet(url, queryStringParams, restHandlerOptions);
   }
 

--- a/src/styles/components/_preview.scss
+++ b/src/styles/components/_preview.scss
@@ -36,6 +36,7 @@ SPDX-License-Identifier: Apache-2.0
 
   $diffRemovedColor: rgb(255 187 187);
   $diffAddedColor: #d4e4f3;
+  $infoMessageColor: #f9e1be;
 
   $previewFontSize: 14px;
 
@@ -262,5 +263,10 @@ SPDX-License-Identifier: Apache-2.0
     dd {
       margin-left: 2em;
     }
+  }
+
+  .info-message {
+    background-color: $infoMessageColor;
+    padding: 8px;
   }
 }

--- a/src/styles/components/_preview.scss
+++ b/src/styles/components/_preview.scss
@@ -247,4 +247,13 @@ SPDX-License-Identifier: Apache-2.0
   .attribute-key {
     font-weight: bold;
   }
+
+  table.alias-table {
+    border-collapse: separate;
+
+    th,
+    td {
+      padding: 4px;
+    }
+  }
 }

--- a/src/styles/components/_preview.scss
+++ b/src/styles/components/_preview.scss
@@ -229,12 +229,22 @@ SPDX-License-Identifier: Apache-2.0
     }
   }
 
-  .diff-html-removed {
+  .diff-html-removed,
+  .deleted {
     background-color: $diffRemovedColor;
     text-decoration: line-through;
   }
 
-  .diff-html-added {
+  .diff-html-added,
+  .new {
     background-color: $diffAddedColor;
+  }
+
+  .attribute-name {
+    margin-right: 100px;
+  }
+
+  .attribute-key {
+    font-weight: bold;
   }
 }

--- a/src/styles/components/_preview.scss
+++ b/src/styles/components/_preview.scss
@@ -248,7 +248,8 @@ SPDX-License-Identifier: Apache-2.0
     font-weight: bold;
   }
 
-  table.alias-table {
+  table.alias-table,
+  table.codes-table {
     border-collapse: separate;
 
     th,

--- a/src/styles/components/_preview.scss
+++ b/src/styles/components/_preview.scss
@@ -34,6 +34,9 @@ SPDX-License-Identifier: Apache-2.0
   $tableBorderColor: #425563;
   $tableHeadBackgroundColor: $nhsDarkBlueColor;
 
+  $diffRemovedColor: rgb(255 187 187);
+  $diffAddedColor: #d4e4f3;
+
   $previewFontSize: 14px;
 
   font-family: 'Frutiger W01', Helvetica, Arial, Sans-serif;
@@ -135,8 +138,6 @@ SPDX-License-Identifier: Apache-2.0
     border: 1px solid $tableBorderColor;
     margin-left: 0;
 
-
-
     strong,
     b {
       font-weight: bolder;
@@ -157,7 +158,13 @@ SPDX-License-Identifier: Apache-2.0
       }
     }
 
-    th.notes, td.mandation, td.rules, td.groupRepeats, td.mandation-header, td.or-header, td.elements-header {
+    th.notes,
+    td.mandation,
+    td.rules,
+    td.groupRepeats,
+    td.mandation-header,
+    td.or-header,
+    td.elements-header {
       width: 4em;
       text-align: center;
     }
@@ -165,7 +172,9 @@ SPDX-License-Identifier: Apache-2.0
       text-align: left;
     }
 
-    td.mandation-header, td.or-header, td.elements-header {
+    td.mandation-header,
+    td.or-header,
+    td.elements-header {
       vertical-align: middle;
       font-weight: bold;
     }
@@ -218,5 +227,14 @@ SPDX-License-Identifier: Apache-2.0
         }
       }
     }
+  }
+
+  .diff-html-removed {
+    background-color: $diffRemovedColor;
+    text-decoration: line-through;
+  }
+
+  .diff-html-added {
+    background-color: $diffAddedColor;
   }
 }

--- a/src/styles/components/_preview.scss
+++ b/src/styles/components/_preview.scss
@@ -257,4 +257,10 @@ SPDX-License-Identifier: Apache-2.0
       padding: 4px;
     }
   }
+
+  div.format-length-detail {
+    dd {
+      margin-left: 2em;
+    }
+  }
 }


### PR DESCRIPTION
Resolves #29 
Resolves #6 

Simple adjustments to support the change paper preview - mostly styling.

This PR depends on:

- MauroDataMapper-NHSD/mdm-plugin-nhs-data-dictionary#78

To test:

1. Sign in to the Orchestrator
2. Click on the "Changes" nav link
3. Select an in-flight branch
4. Click the "Run" button
5. Wait...
6. Review the (approximate) content that would go into the PDF