### PR TITLE
Fix rendering of short description previews to render HTML correctly

### DIFF
--- a/src/app/preview/preview-detail/preview-detail.component.html
+++ b/src/app/preview/preview-detail/preview-detail.component.html
@@ -36,7 +36,10 @@ SPDX-License-Identifier: Apache-2.0
 
           <!-- Short Description -->
           <div *ngIf="detail!.shortDescription" class="- topic/body body">
-            <p class="- topic/shortdesc shortdesc">{{ detail!.shortDescription }}</p>
+            <p
+              class="- topic/shortdesc shortdesc"
+              [innerHTML]="detail!.shortDescription"
+            ></p>
           </div>
 
           <!-- Format / Length -->


### PR DESCRIPTION
A short description will now render HTML correctly. For example, if there is HTML content in the short description, such as a hyperlink, it renders correctly in the preview and not as a plain string.