### PR TITLE
gh-35 Update change paper preview with working hyperlinks

### DIFF
--- a/src/app/changes/changes-home/changes-home.component.html
+++ b/src/app/changes/changes-home/changes-home.component.html
@@ -97,7 +97,11 @@ SPDX-License-Identifier: Apache-2.0
         <table>
           <tr *ngFor="let changedItem of stereotypedChange.changedItems">
             <td>
-              <a href="">{{ changedItem.name }}</a>
+              <a
+                class="jump-link"
+                (click)="summaryLinkClicked(stereotypedChange, changedItem)"
+                >{{ changedItem.name }}</a
+              >
             </td>
             <td>
               {{ getChangeTypeString(changedItem) }}
@@ -109,6 +113,7 @@ SPDX-License-Identifier: Apache-2.0
       <div *ngFor="let stereotypedChange of changePaperPreview.changes">
         <h2>{{ stereotypedChange.stereotype }}</h2>
         <div *ngFor="let changedItem of stereotypedChange.changedItems">
+          <a [id]="getChangeId(stereotypedChange, changedItem)"></a>
           <h3>{{ changedItem.name }}</h3>
           <div *ngFor="let change of changedItem.changes">
             <h4>{{ change.changeType }}</h4>

--- a/src/app/changes/changes-home/changes-home.component.scss
+++ b/src/app/changes/changes-home/changes-home.component.scss
@@ -44,4 +44,11 @@ SPDX-License-Identifier: Apache-2.0
     flex-flow: row wrap;
     justify-content: space-around;
   }
+
+  /* These tags are not actual hyperlinks so style them to look like they are */
+  a.jump-link {
+    color: #3279b5;
+    text-decoration: underline;
+    cursor: pointer;
+  }
 }

--- a/src/app/changes/changes-home/changes-home.component.ts
+++ b/src/app/changes/changes-home/changes-home.component.ts
@@ -25,10 +25,12 @@ import {
 import {
   Branch,
   ChangedItem,
-  ChangePaperPreview
+  ChangePaperPreview,
+  StereotypedChange
 } from '@mdm/mdm-resources/mdm-resources/adapters/nhs-data-dictionary.model';
 import { DataDictionaryService } from '@mdm/core/data-dictionary/data-dictionary.service';
 import { finalize } from 'rxjs/operators';
+import { ViewportScroller } from '@angular/common';
 
 @Component({
   selector: 'mdm-changes-home',
@@ -45,7 +47,8 @@ export class ChangesHomeComponent implements OnInit {
   constructor(
     private dataDictionary: DataDictionaryService,
     private uiRouterGlobals: UIRouterGlobals,
-    private stateHandler: StateHandlerService
+    private stateHandler: StateHandlerService,
+    private viewportScroller: ViewportScroller
   ) {}
 
   run(): void {
@@ -66,6 +69,17 @@ export class ChangesHomeComponent implements OnInit {
 
   getChangeTypeString(changedItem: ChangedItem) {
     return changedItem.changes.map((c) => c.changeType).join(', ');
+  }
+
+  getChangeId(stereotypedChange: StereotypedChange, changedItem: ChangedItem) {
+    return `${stereotypedChange.stereotype}_${changedItem.name}`;
+  }
+
+  summaryLinkClicked(stereotypedChange: StereotypedChange, changedItem: ChangedItem) {
+    // Simulate an <a href="page#section"> link click
+    this.viewportScroller.scrollToAnchor(
+      this.getChangeId(stereotypedChange, changedItem)
+    );
   }
 
   private load(): void {


### PR DESCRIPTION
Summary of changes links now jump to the headings in the page.

Fixes #35 

To test, generate a change paper in the preview:

1. Sign in to the Orchestrator
2. Click on "Changes"
3. Select a branch, then click "Run"

When the preview is rendered, click on any hyperlink listed under the "Summary of Changes" heading. You should then jump to that section.