### PR TITLE
Update HTML preview of data set specifications

### DIFF
--- a/src/app/preview/preview-detail/preview-detail.component.html
+++ b/src/app/preview/preview-detail/preview-detail.component.html
@@ -139,10 +139,7 @@ SPDX-License-Identifier: Apache-2.0
             title="Specification"
             [anchor]="getTableOfContentsLink('Specification')?.anchor"
           >
-            <div
-              class="- topic/body body specification"
-              [innerHTML]="detail.definition"
-            ></div>
+            <div [innerHTML]="detail.definition"></div>
           </mdm-preview-expandable-panel>
 
           <!-- Attributes (Table, for Classes only)-->


### PR DESCRIPTION
All HTML is generated in the backend now

Minor change.

Resolves MauroDataMapper-NHSD/mdm-plugin-nhs-data-dictionary#147